### PR TITLE
Fixed modal-title display

### DIFF
--- a/ekko-lightbox.coffee
+++ b/ekko-lightbox.coffee
@@ -178,10 +178,10 @@ EkkoLightbox.prototype = {
 	updateTitleAndFooter: ->
 		header = @modal_content.find('.modal-header')
 		footer = @modal_content.find('.modal-footer')
-		title = @$element.data('title') || "&nbsp;"
+		title = @$element.data('title') || ""
 		caption = @$element.data('footer') || ""
-		header.css('display', '').find('.modal-title').html(title)
-		if title or @options.always_show_close then header.css('display', '') else header.css('display', 'none')
+
+		if title or @options.always_show_close then header.css('display', '').find('.modal-title').html(title || "&nbsp;") else header.css('display', 'none')
 		if caption then footer.css('display', '').html(caption) else footer.css('display', 'none')
 		@
 


### PR DESCRIPTION
Modified logic in updateTitleAndFooter() so modal-title always follows the "always_show_close" option.

Before, when "always_show_close" set to false, only first modal had hidden title - when navigating left/right the title showed up, even if empty (because of added "nbsp;").
