### PR TITLE
Added no_related option and data-norelated tag to suppress related videos at end of play

### DIFF
--- a/ekko-lightbox.coffee
+++ b/ekko-lightbox.coffee
@@ -222,9 +222,10 @@ EkkoLightbox.prototype = {
 		@
 
 	showYoutubeVideo : (id) ->
+		if @$element.attr('data-norelated')? || @options.no_related then rel="&rel=0" else rel=""
 		width = @checkDimensions( @$element.data('width') || 560 )
 		height = width / ( 560/315 ) # aspect ratio
-		@showVideoIframe('//www.youtube.com/embed/' + id + '?badge=0&autoplay=1&html5=1', width, height)
+		@showVideoIframe('//www.youtube.com/embed/' + id + '?badge=0&autoplay=1&html5=1' + rel, width, height)
 
 	showVimeoVideo : (id) ->
 		width = @checkDimensions( @$element.data('width') || 560 )
@@ -332,6 +333,7 @@ $.fn.ekkoLightbox = ( options ) ->
 			remote : $this.attr('data-remote') || $this.attr('href')
 			gallery_parent_selector : $this.attr('data-parent')
 			type : $this.attr('data-type')
+			no_related : false if $this.attr('data-norelated')
 		}, options, $this.data())
 		new EkkoLightbox(@, options)
 		@
@@ -343,6 +345,7 @@ $.fn.ekkoLightbox.defaults = {
 	directional_arrows: true #display the left / right arrows or not
 	type: null #force the lightbox into image / youtube mode. if null, or not image|youtube|vimeo; detect it
 	always_show_close: true #always show the close button, even if there is no title
+	no_related: false
 	loadingMessage: 'Loading...',
 	onShow : ->
 	onShown : ->

--- a/ekko-lightbox.coffee
+++ b/ekko-lightbox.coffee
@@ -333,7 +333,6 @@ $.fn.ekkoLightbox = ( options ) ->
 			remote : $this.attr('data-remote') || $this.attr('href')
 			gallery_parent_selector : $this.attr('data-parent')
 			type : $this.attr('data-type')
-			no_related : false if $this.attr('data-norelated')
 		}, options, $this.data())
 		new EkkoLightbox(@, options)
 		@

--- a/examples/index.html
+++ b/examples/index.html
@@ -168,6 +168,13 @@
 										<td>Message injected for loading</td>
 										<td></td>
 									</tr>
+									<tr>
+										<td>no_related</td>
+										<td>boolean</td>
+										<td><code>false</code></td>
+										<td>Don't show related videos when finished playing</td>
+										<td><code>data-norelated</code></td>
+									</tr>
 								</tbody>
 							</table>
                     	</div>
@@ -247,6 +254,7 @@
                     <p>You can use various YouTube URL formats, the regex used is: <code>/^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|\&v=)([^#\&\?]*).*/</code></p>
                     <p><a href="http://www.youtube.com/watch?v=k6mFF3VmVAs" data-toggle="lightbox">Ghostpoet - Cash and Carry Me Home</a></p>
                     <p><a href="http://youtu.be/b0jqPvpn3sY" data-toggle="lightbox">Tame Impala - Elephant (using youtu.be link)</a></p>
+                    <p><a href="http://www.youtube.com/watch?v=k6mFF3VmVAs" data-norelated data-toggle="lightbox">Ghostpoet - Cash and Carry Me Home</a> (suppress related videos with data-norelated)</p>
                     <br />
                     <h4>Vimeo</h4>
                     <p>You cannot embed Vimeo videos using the standard url (ie http://vimeo.com/80629469); you must link to the embed source (ie player.vimeo.com/video/80629469). This will mean your link url - if the JavaScript fails, will open the full screen player (try opening the first link below in a new tab); the solution to this is to set the lightbox source directly - the second link below does this.</p>


### PR DESCRIPTION
This change adds a boolean no_related option (defaults to false) and a corresponding tag 'data-norelated' that disable Youtube's "related videos" from showing at the end of playback.  

The patch also updates the options table in the example page and adds an usage example for the new tag in Example 3.

Fixes #66 