### PR TITLE
update license info

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,5 +33,5 @@
         "jquery",
         "modal"
     ],
-    "license": "GNU GENERAL PUBLIC LICENSE"
+    "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
 	"bugs": {
 		"url": "https://github.com/ashleydw/lightbox/issues"
 	},
-	"license": {
-		"type": "GNU GENERAL PUBLIC LICENSE",
-		"url": "https://github.com/ashleydw/lightbox/blob/master/LICENSE.txt"
-	},
+	"license": "MIT",
 	"devDependencies": {
 		"grunt": "^0.4.5",
 		"grunt-banner": "^0.6.0",


### PR DESCRIPTION
The license field in package.json and bower.json are still GNU.