### PR TITLE
Identify arrows independently of user-defined classes

### DIFF
--- a/ekko-lightbox.coffee
+++ b/ekko-lightbox.coffee
@@ -85,7 +85,7 @@ EkkoLightbox.prototype = {
 
 				# add the directional arrows to the modal
 				if @options.directional_arrows && @gallery_items.length > 1
-					@lightbox_container.append('<div class="ekko-lightbox-nav-overlay"><a href="#" class="'+@strip_stops(@options.left_arrow_class)+'"></a><a href="#" class="'+@strip_stops(@options.right_arrow_class)+'"></a></div>')
+					@lightbox_container.append('<div class="ekko-lightbox-nav-overlay"><a href="#" class="left-arrow '+@strip_stops(@options.left_arrow_class)+'"></a><a href="#" class="right-arrow '+@strip_stops(@options.right_arrow_class)+'"></a></div>')
 					@modal_arrows = @lightbox_container.find('div.ekko-lightbox-nav-overlay').first()
 					@lightbox_container.find('a'+@strip_spaces(@options.left_arrow_class)).on 'click', (event) =>
 						event.preventDefault()

--- a/ekko-lightbox.less
+++ b/ekko-lightbox.less
@@ -44,14 +44,14 @@
     text-decoration: none;
   }
 
-  .glyphicon-chevron-left {
+  .left-arrow {
     padding-left:15px;
     float:left;
     left:0;
     text-align: left;
   }
 
-  .glyphicon-chevron-right {
+  .right-arrow {
     padding-right:15px;
     float:right;
     right:0;


### PR DESCRIPTION
We're using fontawesome for all of our icons, not glyphicons, so I set the left and right arrow classes accordingly:

	$.fn.ekkoLightbox.defaults.left_arrow_class = ".fa .fa-chevron-left";
	$.fn.ekkoLightbox.defaults.right_arrow_class = ".fa .fa-chevron-right";

The CSS, however, assumes that the arrows' classes are not changed:

https://github.com/ashleydw/lightbox/blob/master/dist/ekko-lightbox.css#L46

This means that the right arrow is not visible because the styling is not applied. You can see me pointing at the right-arrow in the element inspector, and where Chromium is rendering it.

![ekkolightbox-arrow](https://cloud.githubusercontent.com/assets/74533/18386192/3369f392-768d-11e6-9bd3-c7407093bdf7.png)

I've solved this by always adding ekko-specific classes to the arrows, and referencing those from the CSS.